### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0]
+
+### ⛰️ Features
+
+- Precision 0 means automatic; use that when serialising - ([fc1712c](https://github.com/crazyscot/engineering_repr/commit/fc1712c2c84f5e5dcf3521aea8863db4a6180e6f))
+- Support serde - ([088ebfd](https://github.com/crazyscot/engineering_repr/commit/088ebfd194a704b31b7f862486f780abf1d50740))
+- Initial implementation - ([ee1bcc6](https://github.com/crazyscot/engineering_repr/commit/ee1bcc6fd8136c2b8dbfd25060060ebaa6547c3d))


### PR DESCRIPTION
## 🤖 New release
* `engineering-repr`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0]

### ⛰️ Features

- Precision 0 means automatic; use that when serialising - ([fc1712c](https://github.com/crazyscot/engineering_repr/commit/fc1712c2c84f5e5dcf3521aea8863db4a6180e6f))
- Support serde - ([088ebfd](https://github.com/crazyscot/engineering_repr/commit/088ebfd194a704b31b7f862486f780abf1d50740))
- Initial implementation - ([ee1bcc6](https://github.com/crazyscot/engineering_repr/commit/ee1bcc6fd8136c2b8dbfd25060060ebaa6547c3d))

### 📚 Documentation

- README badges, explanatory table, tweak diagram - ([489dfce](https://github.com/crazyscot/engineering_repr/commit/489dfce2278dd5d37c8a846bf1fb78e961a04824))

### 🧪 Testing

- Add local coverage script, close up gaps in coverage - ([75185f2](https://github.com/crazyscot/engineering_repr/commit/75185f239b830805858e0211f538784a6851e9ad))

### 🏗️ Build, packaging & CI

- Add release-plz config - ([7c3b6b9](https://github.com/crazyscot/engineering_repr/commit/7c3b6b9ffcecd7cc792090a437bcb6e2f068c636))
- Add coveralls - ([037c904](https://github.com/crazyscot/engineering_repr/commit/037c90463f4b0459ae604884208e5941568a63f2))
- Create rust.yml - ([fed4e27](https://github.com/crazyscot/engineering_repr/commit/fed4e27089af01b567bf71ba24a8bb6faff30feb))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).