### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/crazyscot/engineering_repr/compare/v0.1.0...v0.2.0)
+
+### ⛰️ Features
+
+- [**breaking**] Serde support is now behind a feature flag - ([30700e7](https://github.com/crazyscot/engineering_repr/commit/30700e78e7b1f12b8f4abe42f21688a0bc0101a5))
+- Error implements std::error::Error (via thiserror) - ([e40fd48](https://github.com/crazyscot/engineering_repr/commit/e40fd485a784f4a25bec7e32116f2e8d9928ccd8))
+
+### 📚 Documentation
+
+- Improve README - ([4a3c7f9](https://github.com/crazyscot/engineering_repr/commit/4a3c7f91d7cfea1b9b7b179f7ce84f3d2790f7e2))
+- Replace bulky png image with an svg - ([f6e7cd5](https://github.com/crazyscot/engineering_repr/commit/f6e7cd56a4c5c85ddbdc899cfd491a7148e81959))
+
+### 🏗️ Build, packaging & CI
+
+- Run actions on dev branch - ([e81526d](https://github.com/crazyscot/engineering_repr/commit/e81526d1e22b495de7d9501d1e87e19d6af6a991))
+- Add dependabot config - ([af773ca](https://github.com/crazyscot/engineering_repr/commit/af773ca7c7007b71ac47fbc378a8935773246374))
+- Tidy up dependencies - ([f03f184](https://github.com/crazyscot/engineering_repr/commit/f03f18424e30da7ad20f1c2a4296cd799fe5a4ee))
+
+### ⚙️ Miscellaneous Tasks
+
+- Update workflows and IDE config to suit working with feature flags - ([51f4f21](https://github.com/crazyscot/engineering_repr/commit/51f4f21e0ddad7647f6afa182ec8ba5060bdac90))
+- Fix docs badge in README - ([2f9d852](https://github.com/crazyscot/engineering_repr/commit/2f9d8522d66f6f0e0ef369eb917ad24f7de74c89))
+
+
 ## [0.1.0]
 
 ### ⛰️ Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engineering-repr"
 description = "Numeric conversions for engineering notation (1.23k) and the RKM code variant (1k23)"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Ross Younger <qcp@crazyscot.com>"]
 license = "MIT"

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,18 @@
+I think we need our error type to impl StdError for qcp?
+/ impl it, basics
+/ consider implementing source i.e. pivot from enum to struct holding box/dyn/stderror. No, maybe one day if we get more advanced errors.
+
+/Is there any change we can remove crates we don't need?
+    traits - needed
+    rational - will be needed soon
+/    serde - hmm
+
+dependabot !
+
+Negative exponent. Should be pretty straightforward actually. But open a ticket...
+- add to_ratio
+- To String
+- From String
+- To Float Lossy [for all storage types...]
+- grep "negative expo" straggler comment.
+...


### PR DESCRIPTION
## 🤖 New release
* `engineering-repr`: 0.1.0 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/crazyscot/engineering_repr/compare/v0.1.0...v0.2.0)

### ⛰️ Features

- [**breaking**] Serde support is now behind a feature flag - ([30700e7](https://github.com/crazyscot/engineering_repr/commit/30700e78e7b1f12b8f4abe42f21688a0bc0101a5))
- Error implements std::error::Error (via thiserror) - ([e40fd48](https://github.com/crazyscot/engineering_repr/commit/e40fd485a784f4a25bec7e32116f2e8d9928ccd8))

### 📚 Documentation

- Improve README - ([4a3c7f9](https://github.com/crazyscot/engineering_repr/commit/4a3c7f91d7cfea1b9b7b179f7ce84f3d2790f7e2))
- Replace bulky png image with an svg - ([f6e7cd5](https://github.com/crazyscot/engineering_repr/commit/f6e7cd56a4c5c85ddbdc899cfd491a7148e81959))

### 🏗️ Build, packaging & CI

- Run actions on dev branch - ([e81526d](https://github.com/crazyscot/engineering_repr/commit/e81526d1e22b495de7d9501d1e87e19d6af6a991))
- Add dependabot config - ([af773ca](https://github.com/crazyscot/engineering_repr/commit/af773ca7c7007b71ac47fbc378a8935773246374))
- Tidy up dependencies - ([f03f184](https://github.com/crazyscot/engineering_repr/commit/f03f18424e30da7ad20f1c2a4296cd799fe5a4ee))

### ⚙️ Miscellaneous Tasks

- Update workflows and IDE config to suit working with feature flags - ([51f4f21](https://github.com/crazyscot/engineering_repr/commit/51f4f21e0ddad7647f6afa182ec8ba5060bdac90))
- Fix docs badge in README - ([2f9d852](https://github.com/crazyscot/engineering_repr/commit/2f9d8522d66f6f0e0ef369eb917ad24f7de74c89))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).